### PR TITLE
Add basic LangChain/LangGraph project/task framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # VibeBfx
-Vibe Bioinformatics
+
+A minimal framework for agentic "vibe bioinformatics".  Projects are
+simple directories and each unit of work is a *task* stored in a
+subdirectory containing a `chat.txt` conversation history and a `log.txt`
+file with notes or other metadata.
+
+The core library is built on top of [LangChain](https://python.langchain.com)
+and [LangGraph](https://langchain-ai.github.io/langgraph/) to provide a
+text interface reminiscent of Codex.
+
+## Quick start
+
+```bash
+pip install -e .
+
+# Start an interactive session for a project and task
+vibe-bfx my_project first-task --prompt "hello"
+```
+
+Running the command above will create directories
+`my_project/first-task/chat.txt` and `my_project/first-task/log.txt` which
+store the conversation and log respectively.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "vibe_bfx"
+version = "0.1.0"
+description = "Simple agentic vibe bioinformatics framework"
+authors = [{name = "VibeBfx"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "langchain",
+    "langgraph",
+]
+
+[project.scripts]
+vibe-bfx = "vibe_bfx.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = [{name = "VibeBfx"}]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "langchain",
-    "langgraph",
+    "langchain>=0.1.0,<1.0.0",
+    "langgraph>=0.1.0,<1.0.0",
 ]
 
 [project.scripts]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from vibe_bfx import Project
+from langchain.schema import AIMessage
+
+
+class EchoModel:
+    def invoke(self, messages):
+        return AIMessage(content=messages[-1].content)
+
+
+def test_project_and_task(tmp_path: Path):
+    project = Project(tmp_path / "proj")
+    task = project.create_task("t1")
+    assert (task.chat_file).exists()
+    assert (task.log_file).exists()
+
+    task.append_chat("user", "hi")
+    task.append_log("started")
+
+    assert "user: hi" in task.chat_file.read_text()
+    assert "started" in task.log_file.read_text()
+
+
+def test_run_chat(tmp_path: Path):
+    project = Project(tmp_path / "proj")
+    task = project.create_task("t1")
+    response = task.run_chat("echo", model=EchoModel())
+    assert response == "echo"
+    assert "assistant: echo" in task.chat_file.read_text()

--- a/vibe_bfx/__init__.py
+++ b/vibe_bfx/__init__.py
@@ -1,0 +1,6 @@
+"""Simple agentic vibe bioinformatics framework."""
+
+from .project import Project
+from .task import Task
+
+__all__ = ["Project", "Task"]

--- a/vibe_bfx/cli.py
+++ b/vibe_bfx/cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+
+from .project import Project
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Vibe BFX text interface")
+    parser.add_argument("project", help="Project directory")
+    parser.add_argument("task", help="Task name inside the project")
+    parser.add_argument("--prompt", help="Optional prompt for a single turn")
+    args = parser.parse_args()
+
+    project = Project(args.project)
+    task = project.get_task(args.task) or project.create_task(args.task)
+
+    if args.prompt:
+        response = task.run_chat(args.prompt)
+        print(response)
+        return
+
+    try:
+        while True:
+            prompt = input("> ")
+            if not prompt.strip():
+                continue
+            response = task.run_chat(prompt)
+            print(response)
+    except (EOFError, KeyboardInterrupt):
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/vibe_bfx/project.py
+++ b/vibe_bfx/project.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .task import Task
+
+
+class Project:
+    """Represents a top-level project directory.
+
+    Parameters
+    ----------
+    path: str | Path
+        Location of the project directory. If it does not exist it will be
+        created automatically.
+    """
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    def create_task(self, name: str) -> Task:
+        """Create and return a task within this project."""
+        task_path = self.path / name
+        task_path.mkdir(parents=True, exist_ok=True)
+        return Task(task_path)
+
+    def get_task(self, name: str) -> Optional[Task]:
+        """Return a task if it exists, otherwise ``None``."""
+        task_path = self.path / name
+        if task_path.exists() and task_path.is_dir():
+            return Task(task_path)
+        return None
+
+    def list_tasks(self) -> Iterable[str]:
+        """Yield the names of tasks in this project."""
+        for p in sorted(self.path.iterdir()):
+            if p.is_dir():
+                yield p.name

--- a/vibe_bfx/task.py
+++ b/vibe_bfx/task.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, TypedDict
+
+from langchain.schema import BaseMessage, HumanMessage
+
+
+class Task:
+    """Represents a unit of work inside a project."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self.path.mkdir(parents=True, exist_ok=True)
+        self.chat_file = self.path / "chat.txt"
+        self.log_file = self.path / "log.txt"
+        for f in (self.chat_file, self.log_file):
+            f.touch(exist_ok=True)
+
+    def append_chat(self, role: str, message: str) -> None:
+        with self.chat_file.open("a", encoding="utf-8") as fh:
+            fh.write(f"{role}: {message}\n")
+
+    def append_log(self, entry: str) -> None:
+        with self.log_file.open("a", encoding="utf-8") as fh:
+            fh.write(entry + "\n")
+
+    def run_chat(self, prompt: str, model=None) -> str:
+        """Run a single chat turn using LangChain and LangGraph.
+
+        Parameters
+        ----------
+        prompt:
+            The user prompt to send to the model.
+        model:
+            Optional LangChain chat model. If ``None`` a default
+            :class:`langchain.chat_models.ChatOpenAI` model is used.
+        """
+
+        if model is None:
+            from langchain.chat_models import ChatOpenAI
+            model = ChatOpenAI()
+
+        from langgraph.graph import StateGraph, END
+
+        class ChatState(TypedDict):
+            messages: List[BaseMessage]
+
+        def call_model(state: ChatState) -> ChatState:
+            response = model.invoke(state["messages"])
+            return {"messages": state["messages"] + [response]}
+
+        graph = StateGraph(ChatState)
+        graph.add_node("model", call_model)
+        graph.add_edge("model", END)
+        graph.set_entry_point("model")
+        app = graph.compile()
+
+        result = app.invoke({"messages": [HumanMessage(content=prompt)]})
+        response = result["messages"][-1].content
+
+        self.append_chat("user", prompt)
+        self.append_chat("assistant", response)
+        self.append_log(f"Prompt: {prompt}\nResponse: {response}\n")
+
+        return response

--- a/vibe_bfx/task.py
+++ b/vibe_bfx/task.py
@@ -25,7 +25,7 @@ class Task:
         with self.log_file.open("a", encoding="utf-8") as fh:
             fh.write(entry + "\n")
 
-    def run_chat(self, prompt: str, model=None) -> str:
+    def run_chat(self, prompt: str, model: Optional[Any] = None) -> str:
         """Run a single chat turn using LangChain and LangGraph.
 
         Parameters


### PR DESCRIPTION
## Summary
- implement `Project` and `Task` classes to manage directory-based projects and task logs
- add LangChain/LangGraph powered chat with CLI interface
- document usage and package metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68925e04773c8323b292059a60cc3943