### PR TITLE
Implement planner and worker agents

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from vibe_bfx import Planner, Project
+
+
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+def test_planner_uses_workers(tmp_path: Path) -> None:
+    project = Project(tmp_path / "proj")
+    task = project.create_task("t1")
+    planner = Planner(task)
+
+    report = planner.run(tool=add, inputs={"a": 1, "b": 2})
+
+    assert "Result: 3" in report
+
+    log_text = task.log_file.read_text()
+    assert "environment: docker" in log_text
+    assert "execution result: 3" in log_text
+    assert "Result: 3" in log_text

--- a/vibe_bfx/__init__.py
+++ b/vibe_bfx/__init__.py
@@ -2,5 +2,13 @@
 
 from .project import Project
 from .task import Task
+from .agents import Planner, Executor, EnvironmentManager, Analyst
 
-__all__ = ["Project", "Task"]
+__all__ = [
+    "Project",
+    "Task",
+    "Planner",
+    "Executor",
+    "EnvironmentManager",
+    "Analyst",
+]

--- a/vibe_bfx/agents.py
+++ b/vibe_bfx/agents.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+from .task import Task
+
+
+class Executor:
+    """Run a tool with specified inputs and parameters."""
+
+    def run(
+        self,
+        tool: Callable[..., Any],
+        *,
+        inputs: Dict[str, Any],
+        params: Dict[str, Any] | None = None,
+    ) -> Any:
+        params = params or {}
+        return tool(**inputs, **params)
+
+
+class EnvironmentManager:
+    """Find or create an environment for running a tool."""
+
+    def prepare(self, tool_name: str) -> str:
+        """Return the chosen environment for ``tool_name``.
+
+        The current implementation simply prefers Docker and falls back to
+        Conda. Future versions could perform actual environment resolution.
+        """
+
+        for env in ("docker", "conda"):
+            return env
+        return "local"
+
+
+class Analyst:
+    """Analyze results and produce a textual report."""
+
+    def analyze(self, result: Any) -> str:
+        return f"Result: {result}"
+
+
+class Planner:
+    """Assign units of work on a :class:`~vibe_bfx.task.Task` to worker agents."""
+
+    def __init__(self, task: Task):
+        self.task = task
+        self.executor = Executor()
+        self.env_manager = EnvironmentManager()
+        self.analyst = Analyst()
+
+    def run(
+        self,
+        tool: Callable[..., Any],
+        *,
+        inputs: Dict[str, Any],
+        params: Dict[str, Any] | None = None,
+    ) -> str:
+        env = self.env_manager.prepare(getattr(tool, "__name__", "tool"))
+        self.task.append_log(f"environment: {env}")
+        result = self.executor.run(tool, inputs=inputs, params=params)
+        self.task.append_log(f"execution result: {result}")
+        report = self.analyst.analyze(result)
+        self.task.append_log(report)
+        return report

--- a/vibe_bfx/task.py
+++ b/vibe_bfx/task.py
@@ -8,7 +8,11 @@ from datetime import datetime
 
 from langchain.schema import BaseMessage, HumanMessage
 from langgraph.graph import END, START, StateGraph
-from langchain_community import ChatOpenAI
+from langchain_community.chat_models import ChatOpenAI
+
+
+class ChatState(TypedDict):
+    messages: List[BaseMessage]
 
 
 class Task:
@@ -57,9 +61,6 @@ class Task:
                 timeout=None,
                 max_retries=2,
             )
-
-        class ChatState(TypedDict):
-            messages: List[BaseMessage]
 
         def call_model(state: ChatState) -> ChatState:
             node = "model"


### PR DESCRIPTION
## Summary
- Add agent framework with Executor, EnvironmentManager, Analyst, and Planner orchestrating them
- Export new agents in package init and fix ChatOpenAI import/ChatState typing
- Add tests covering planner workflow and configure pytest path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893857d3e9c832399f53ea053e6741b