### PR TITLE
Add reserved config keys and metadata field mapping

### DIFF
--- a/vibe_bfx/project.py
+++ b/vibe_bfx/project.py
@@ -21,6 +21,21 @@ class Project:
         created automatically.
     """
 
+    # Reserved configuration keys and their default values. These are
+    # automatically populated in ``project.config`` to provide a stable API
+    # regardless of whether users explicitly set them in ``config.yaml``.
+    _RESERVED_CONFIG_DEFAULTS: dict[str, Any] = {
+        "db_fp": None,
+        "conda_fp": None,
+        "docker_fp": None,
+        "singularity_fp": None,
+        # The column names in ``metadata.csv`` that correspond to the sample ID
+        # and the R1 fastq path. Users may override these in ``config.yaml`` if
+        # their metadata file uses non-standard column names.
+        "sample_id_field_name": "sample_id",
+        "r1_fp_field_name": "r1_fp",
+    }
+
     def __init__(self, path: str | Path):
         self.path = Path(path)
         self.path.mkdir(parents=True, exist_ok=True)
@@ -30,6 +45,10 @@ class Project:
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.metadata = self._load_metadata()
         self.config = self._load_config()
+        # Ensure all reserved keys are present in the configuration with their
+        # default values.
+        for key, default in self._RESERVED_CONFIG_DEFAULTS.items():
+            self.config.setdefault(key, default)
 
     def _load_metadata(self) -> List[dict[str, str]]:
         if self.metadata_path.exists():
@@ -44,6 +63,20 @@ class Project:
                 data = yaml.safe_load(fh)
             return data or {}
         return {}
+
+    def iter_samples(self) -> Iterable[dict[str, str]]:
+        """Yield dictionaries containing ``sample_id`` and ``r1_fp`` for each
+        record in the metadata.
+
+        The ``sample_id`` and ``r1_fp`` column names can be overridden via the
+        ``sample_id_field_name`` and ``r1_fp_field_name`` configuration keys.
+        """
+
+        sample_key = self.config["sample_id_field_name"]
+        r1_key = self.config["r1_fp_field_name"]
+        for row in self.metadata:
+            if sample_key in row and r1_key in row:
+                yield {"sample_id": row[sample_key], "r1_fp": row[r1_key]}
 
     def create_task(self, name: str) -> Task:
         """Create and return a task within this project."""


### PR DESCRIPTION
## Summary
- add reserved config keys for tool paths (db_fp, conda_fp, docker_fp, singularity_fp)
- allow overriding metadata column names via sample_id_field_name and r1_fp_field_name
- expose helper to iterate standardized sample records

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893881b4bf8832388f3608a26660b60