### PR TITLE
feat: add agent logging system

### DIFF
--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from vibe_bfx import Planner, Project
+from vibe_bfx import Project
 
 
 def add(a: int, b: int) -> int:
@@ -12,13 +12,29 @@ def add(a: int, b: int) -> int:
 def test_planner_uses_workers(tmp_path: Path) -> None:
     project = Project(tmp_path / "proj")
     task = project.create_task("t1")
-    planner = Planner(task)
-
-    report = planner.run(tool=add, inputs={"a": 1, "b": 2})
+    report = task.run(
+        "add numbers",
+        tool=add,
+        inputs={"a": 1, "b": 2},
+    )
 
     assert "Result: 3" in report
 
-    log_text = task.log_file.read_text()
-    assert "environment: docker" in log_text
-    assert "execution result: 3" in log_text
-    assert "Result: 3" in log_text
+    chat_text = task.chat_file.read_text()
+    assert "user: add numbers" in chat_text
+    assert "assistant: Result: 3" in chat_text
+
+    # log references
+    refs = task.log_file.read_text().splitlines()
+    assert any("planner" in r for r in refs)
+    assert any("environment" in r for r in refs)
+    assert any("executor" in r for r in refs)
+    assert any("analyst" in r for r in refs)
+
+    # verify log contents
+    env_log = next((task.logs_dir.glob("*_environment.log"))).read_text()
+    assert "environment: docker" in env_log
+    exec_log = next((task.logs_dir.glob("*_executor.log"))).read_text()
+    assert "execution result: 3" in exec_log
+    analyst_log = next((task.logs_dir.glob("*_analyst.log"))).read_text()
+    assert "Result: 3" in analyst_log


### PR DESCRIPTION
## Summary
- add contextual logging utilities for tasks and agents
- extend planner to log each sub-agent action and reference outputs
- support planner-driven task execution with chat and log tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68938eb1f29c832385ba58b56dccecc3