### PR TITLE
Handle planner responses correctly and import json for runner

### DIFF
--- a/vibe_bfx/agents.py
+++ b/vibe_bfx/agents.py
@@ -1,5 +1,5 @@
 import logging
-from langchain.schema import BaseMessage, HumanMessage
+from langchain.schema import AIMessage, BaseMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel, Field
 from typing import Any, Dict, Sequence
@@ -60,7 +60,10 @@ class Planner:
         print(f"Planner response: {response}")
         print(type(response))
         print(type(response.steps))
-        return BaseMessage(content=response.steps)
+        # Join the individual steps into a single string and return a
+        # well-typed message so downstream components can process it
+        steps_text = "\n".join(response.steps)
+        return AIMessage(content=steps_text)
 
 
 class Runner:

--- a/vibe_bfx/prefect.py
+++ b/vibe_bfx/prefect.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from langchain.schema import BaseMessage, HumanMessage
 from langgraph.graph import END, START, StateGraph


### PR DESCRIPTION
## Summary
- Use `AIMessage` with joined text for planner steps to satisfy pydantic validation
- Import `json` in Prefect workflow to serialize runner outputs

## Testing
- `pytest`
- `python -m vibe_bfx.cli projects/double/ task01 --prompt "Do work"` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0eefb0088323a7df34f29ca66da9